### PR TITLE
The movingTriangle program works now on the Raspberry. There have bee…

### DIFF
--- a/movingTriangle/GLWindow.cpp
+++ b/movingTriangle/GLWindow.cpp
@@ -135,7 +135,12 @@ class GLWindow::I {
 
     
  
-    window = SDL_CreateWindow("NameOfWindow",0,0,screenWidth,screenHeight,
+    window = SDL_CreateWindow(
+      "NameOfWindow",
+      SDL_WINDOWPOS_UNDEFINED,
+      SDL_WINDOWPOS_UNDEFINED,
+      screenWidth,
+      screenHeight,
       SDL_WINDOW_OPENGL|
       SDL_WINDOW_FULLSCREEN|
       SDL_WINDOW_BORDERLESS
@@ -155,6 +160,8 @@ class GLWindow::I {
 
     setSwapInterval();//The swap interval can only be set after obtaining a valid current context.
 
+    checkHardwareAcceleration();
+    
     loadOpenGLFunctions();
 
     renderer->initializeRendering();
@@ -216,6 +223,18 @@ class GLWindow::I {
       return false;
     }
     return true;
+  }
+
+  void checkHardwareAcceleration() {
+    int i = 0;
+    i = SDL_GL_GetAttribute(SDL_GL_ACCELERATED_VISUAL,&i);
+
+    if(i == 1) {
+      std::printf("There is hardware acceleration.\n");
+    }
+    else {
+      std::printf("There is no hardware acceleration.\n");
+    }
   }
 
   void loadOpenGLFunctions() {

--- a/movingTriangle/MovingTriangle.cpp
+++ b/movingTriangle/MovingTriangle.cpp
@@ -57,6 +57,9 @@ class CircleProgram: public Renderer {
     printOpenGLInformation();
     
     glClearColor(0.0f,0.0f,0.0f,1.0f);
+    glClearDepthf(0.0f);
+    glDisable(GL_DEPTH_TEST);
+
 
     createShaderProgram();
 
@@ -70,28 +73,46 @@ class CircleProgram: public Renderer {
 
     shaderProgram.activate();
 
+    printOpenGLError( glGetError() );
     
-    printOpenGLError();
+    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+    printOpenGLError( glGetError() );
     
-    if( glGetError() ) {
-      std::printf( "There has been an OpenGL error.\n" );
-    }
+    x = 0.0;
+    
+    matrix[2] = (GLfloat) x;
+    
+    glUniformMatrix3fv(matrixUniform,1,false,matrix);
+    printOpenGLError( glGetError() );
+    
+    glDrawElements(GL_TRIANGLES,3,GL_UNSIGNED_SHORT,0);
+    printOpenGLError( glGetError() );
+    
+    
   }
   
   void render() override {
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
     
-    
-    x += 0.0025;
+    x += 0.0015;
     if(x > 1.5) {
       x = -1.5;
     }
     
-    matrix[2] = (GLfloat) x;
+    matrix[6] = (GLfloat) x;
     
-    glUniformMatrix3fv(matrixUniform,1,true,matrix);
+    glUniformMatrix3fv(matrixUniform,1,false,matrix);
     
     glDrawElements(GL_TRIANGLES,3,GL_UNSIGNED_SHORT,0);
+    
+    /*
+    auto error = glGetError();
+    
+    if( error != GL_NO_ERROR) {
+      //printOpenGLError(error);
+      stopBoolean = true;
+    }
+    */
   }
 
  private:
@@ -211,8 +232,8 @@ class CircleProgram: public Renderer {
     matrixUniform = shaderProgram.getUniformLocation("theMatrix");
   }
 
-  void printOpenGLError() {
-    GLenum error = glGetError();
+  void printOpenGLError(GLenum error) {
+    //GLenum error = glGetError();
 
     if(error == GL_NO_ERROR) {
       std::printf("No OpenGL error has occurred.\n");
@@ -221,7 +242,7 @@ class CircleProgram: public Renderer {
     
     std::printf("OpenGL error: ");
     
-    switch(glGetError()) {
+    switch(error) {
       case GL_INVALID_ENUM: std::printf("Invalid enum\n"); break;
       case GL_INVALID_VALUE: std::printf("Invalid value\n"); break;
       case GL_INVALID_OPERATION: std::printf("Invalid operation\n"); break;

--- a/movingTriangle/meson.build
+++ b/movingTriangle/meson.build
@@ -3,7 +3,7 @@ project('SDLTest','cpp',
 )
 src=['MovingTriangle.cpp','GLWindow.cpp','glad.cpp','ShaderProgram.cpp']
 
-SDL = dependency('sdl2' ,version : '>=2.0.7')
+SDL = dependency('sdl2' ,version : '>=2.0.5')
 
 threads = dependency('threads')
 
@@ -13,5 +13,3 @@ program = executable('a.out',src,dependencies : [SDL,threads],
   include_directories: extraIncludeDirectories,
   cpp_pch : 'pch/PrecompiledHeader.hpp'
 )
-
-#  test('Bladiebla',program, timeout: 3600)


### PR DESCRIPTION
…n two problems:

SDL2 did not use the correct OpenGL ES driver and I had used the function glUniformMatrix3fv
in a wrong way. The description of this function can be found here.

https://www.khronos.org/registry/OpenGL-Refpages/es2.0/

It turns out that the transpose argument of glUniformMatrix3fv has to be "false" in OpenGL ES 2.0.

To get SDL2 to use the correct OpenGL ES driver I did the following.
- Invoke "sudo rpi-update" in a terminal. I am not sure whether this option is required.
- Install the development version of SDL2, version 2.0.8, from source with the options
  --disable-audio
  --disable-render
  --enable-video
  --disable-pulseaudio
  --disable-esd
  --disable-video-mir
  --disable-video-wayland
  --disable-video-opengl
  --host=arm-raspberry-linux-gnueabihf
  --disable-video-x11

I am not sure whether using rpi-update was required, but the above two steps solved the driver
problem. I can give more about these steps.